### PR TITLE
Fix for OSX Release build

### DIFF
--- a/src/component/touch/Touchable.cpp
+++ b/src/component/touch/Touchable.cpp
@@ -75,12 +75,12 @@ Touchable* Touchable::setMargin(int width, int height)
 
 void Touchable::addTouchable(cocos2d::CCNode* node)
 {
-#ifndef DEBUG
-	for (auto& element : _touchables)
-	{
-		assert(element.get() != node && "Touchable already added!");
-	}
-#endif
+// #ifndef DEBUG
+// 	for (auto& element : _touchables)
+// 	{
+// 		assert(element.get() != node && "Touchable already added!");
+// 	}
+// #endif
 
 	_touchables.emplace_back(node);
 }


### PR DESCRIPTION
I'm not sure if this assert is always used but when i built on Release mode for OSX - i have compilation error (due to -Werror options) because element variable is not used